### PR TITLE
Check the dev mongo server is using the right port

### DIFF
--- a/tests/integration/mongo-dev-server.js
+++ b/tests/integration/mongo-dev-server.js
@@ -1,13 +1,25 @@
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
+const PORT = 51412;
+
 const mongod = new MongoMemoryServer({
   instance: {
     dbName: 'userfeedback',
-    port: 51412,
+    port: PORT,
   },
 });
 
-mongod.getUri().then((uri) => {
-  // eslint-disable-next-line no-console
-  console.info(`mongodb memory server available at ${uri}`);
+// Make sure that the correct port could be used and we haven't fallen-back to a random port number.
+mongod.getPort().then((port) => {
+  if (port !== PORT) {
+    mongod.stop();
+    // eslint-disable-next-line no-console
+    console.error(`Error: port ${PORT} is not available. Do you already have this server running?`);
+    process.exit(1);
+  }
+
+  mongod.getUri().then((uri) => {
+    // eslint-disable-next-line no-console
+    console.info(`mongodb memory server available at ${uri}`);
+  });
 });


### PR DESCRIPTION
By default, mongodb-memory-server will fall back to using a random port if the requested
port is already being used. We want to avoid this for simplicity.

* After starting the server, check the port is correct.
* If not, stop with a warning.