### PR TITLE
Create database indexes via a private setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Returns a 503 response if database is unreachable. 200 OK otherwise.
 
 `GET /healthcheck/`
 
+### Setup
+
+Run database setup commands such as creating indexes.
+This endpoint is protected by authentication.
+Your deployment mechanism should call this endpoint after each deployment.
+
+`POST /setup/`
+
+#### Payload
+
+none
+
 ## Contributing
 
 ### Tests

--- a/lib/database.js
+++ b/lib/database.js
@@ -52,6 +52,19 @@ module.exports.healthcheck = async () => {
 };
 
 /**
+ * Create database indexes. This function only needs to be run once, but should
+ * also be idempotent so that running multiple times doesn't error.
+ */
+module.exports.createIndexes = async () => {
+  const db = await getDb();
+  const collection = db.collection(COLLECTION_NAME);
+
+  // Create an index on the "token" field. This field is used to match requests.
+  // It needs to be indexed for efficient update operations
+  await collection.createIndexes({ token: 1 });
+};
+
+/**
  * @param {Object} data - Data object to be saved into the database
  * @returns {Promise} - A promise which resolves to a unique token
  */

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -58,3 +58,12 @@ az functionapp deployment source config-zip \
   -n $FUNCTION_APP_NAME \
   --src $ZIP_FILE_PATH \
   --build-remote true
+
+# Trigger the setup function. The setup function contains code which should be run once per deployment
+
+# Get setup function URL and key
+SETUP_FUNCTION_URL=$(az functionapp function show --resource-group $RESOURCE_GROUP --name $FUNCTION_APP_NAME --function-name setup --query "invokeUrlTemplate" --output tsv)
+SETUP_FUNCTION_KEY=$(az functionapp function keys list --resource-group $RESOURCE_GROUP --name $FUNCTION_APP_NAME --function-name setup --query "default" --output tsv)
+
+# Empty POST request to the setup function, with an auth header.
+curl -v --header "x-functions-key: $SETUP_FUNCTION_KEY" -d "" $SETUP_FUNCTION_URL

--- a/setup/function.json
+++ b/setup/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/setup/index.js
+++ b/setup/index.js
@@ -1,0 +1,8 @@
+const { handleHealthcheck } = require('../lib/index.js');
+
+const { createIndexes } = require('../lib/database.js');
+
+module.exports = async (context, req) => {
+  await createIndexes();
+  return handleHealthcheck(context, req);
+};


### PR DESCRIPTION
Create database indexes to improve performance. Database operation is called via a private http endpoint which the deployment mechanism triggers post function deployment.