### PR TITLE
update terraform to use updated azurerm app plan and function app

### DIFF
--- a/host.json
+++ b/host.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 3.0.0)"
+    "version": "[4.0.0, 5.0.0)"
   },
   "extensions": {
     "http": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,6 +52,14 @@ terraform -chdir=./terraform apply \
 RESOURCE_GROUP=$(terraform -chdir=./terraform output -raw resource_group_name)
 FUNCTION_APP_NAME=$(terraform -chdir=./terraform output -raw function_app_name)
 
+# Set azure function app runttime setting outside of terraform due to Node 20 runtime app setting not supported at time of this being required
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/23528
+
+az functionapp config set \
+  -g $RESOURCE_GROUP \
+  -n $FUNCTION_APP_NAME \
+  --linux-fx-version "NODE|20"
+
 # Deploy to the functionapp
 az functionapp deployment source config-zip \
   -g $RESOURCE_GROUP \

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,7 +5,7 @@ locals {
 locals {
   common_tags = {
     product = "User Feedback"
-    owner = "mike.monteith@nhs.net"
+    owner = "sikander.ali@nhs.net"
     expires = "Never"
     environment = var.env
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,5 +4,5 @@ output "resource_group_name" {
 }
 
 output "function_app_name" {
-  value = azurerm_function_app.function_app.name
+  value = azurerm_linux_function_app.function_app.name
 }


### PR DESCRIPTION
Upgrade terraform provider version and a workaround for terraform bug - at time of this PR creation terraform can only deploy function application stack up to Node version 18 and we require version 20

https://github.com/hashicorp/terraform-provider-azurerm/issues/23528
